### PR TITLE
annotate and filter with svpack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "scripts/calN50"]
 	path = scripts/calN50
 	url = git@github.com:lh3/calN50.git
+[submodule "svpack"]
+	path = svpack
+	url = git@github.com:amwenger/svpack.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "scripts/calN50"]
 	path = scripts/calN50
 	url = git@github.com:lh3/calN50.git
-[submodule "svpack"]
-	path = svpack
-	url = git@github.com:amwenger/svpack.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "scripts/calN50"]
 	path = scripts/calN50
 	url = git@github.com:lh3/calN50.git
+[submodule "scripts/svpack"]
+	path = scripts/svpack
+	url = git@github.com:amwenger/svpack.git

--- a/process_cohort.smk
+++ b/process_cohort.smk
@@ -84,7 +84,7 @@ targets.extend([svpack_input, svpack_input + '.tbi'])
 # annotate and filter pbsv vcf with svpack
 include: 'rules/cohort_svpack.smk'
 targets.extend([f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.{suffix}"
-                for suffix in ['vcf.gz', 'vcf.gz.tbi']])
+                for suffix in ['vcf.gz', 'vcf.gz.tbi', 'tsv']])
 
 # generate a cohort level deepvariant vcf or use singleton vcf
 include: 'rules/cohort_glnexus.smk'

--- a/process_cohort.smk
+++ b/process_cohort.smk
@@ -81,7 +81,10 @@ include: 'rules/cohort_common.smk'
 include: 'rules/cohort_pbsv.smk'
 targets.extend([svpack_input, svpack_input + '.tbi'])
 
-# TODO: annotate and filter pbsv vcf with svpack
+# annotate and filter pbsv vcf with svpack
+include: 'rules/cohort_svpack.smk'
+targets.extend([f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.{suffix}"
+                for suffix in ['vcf.gz', 'vcf.gz.tbi', 'tsv']])
 
 # generate a cohort level deepvariant vcf or use singleton vcf
 include: 'rules/cohort_glnexus.smk'

--- a/process_cohort.smk
+++ b/process_cohort.smk
@@ -84,7 +84,7 @@ targets.extend([svpack_input, svpack_input + '.tbi'])
 # annotate and filter pbsv vcf with svpack
 include: 'rules/cohort_svpack.smk'
 targets.extend([f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.{suffix}"
-                for suffix in ['vcf.gz', 'vcf.gz.tbi', 'tsv']])
+                for suffix in ['vcf.gz', 'vcf.gz.tbi']])
 
 # generate a cohort level deepvariant vcf or use singleton vcf
 include: 'rules/cohort_glnexus.smk'

--- a/reference.yaml
+++ b/reference.yaml
@@ -13,6 +13,9 @@ ref:
   ensembl_gff: 'reference/ensembl.GRCh38.101.reformatted.gff3.gz'
   gnomad_gnotate: 'resources/slivar/gnomad.hg38.v3.custom.zip'
   hprc_dv_gnotate: 'resources/slivar/hprc.deepvariant.glnexus.hg38.v1.zip'
+  eee_vcf: 'resources/eee/EEE_SV-Pop_1.ALL.sites.20181204.vcf.gz'
+  gnomadsv_vcf: 'resources/gnomadsv/nstd166.GRCh38.variant_call.vcf.gz'
+  hprc_pbsv_vcf: 'resources/hprc/hprc.GRCh38.pbsv.vcf.gz'
   autosomes: ['chr1', 'chr2', 'chr3', 'chr4', 'chr5',
               'chr6', 'chr7', 'chr8', 'chr9', 'chr10',
               'chr11', 'chr12', 'chr13', 'chr14', 'chr15',

--- a/rules/cohort_svpack.smk
+++ b/rules/cohort_svpack.smk
@@ -22,39 +22,39 @@ rule svpack_filter_annotated:
         """
 
 
-info_fields = [
-    'SVTYPE',
-    'SVLEN',
-    'SVANN',
-    'CIPOS',
-    'MATEID',
-    'END'
-    ]
+# info_fields = [
+#     'SVTYPE',
+#     'SVLEN',
+#     'SVANN',
+#     'CIPOS',
+#     'MATEID',
+#     'END'
+#     ]
 
 
-rule slivar_svpack_tsv:
-    input:
-        filt_vcf = f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.vcf.gz",
-        ped = f"cohorts/{cohort}/{cohort}.ped",
-        lof_lookup = config['lof_lookup'],
-        clinvar_lookup = config['clinvar_lookup'],
-        phrank_lookup = f"cohorts/{cohort}/{cohort}_phrank.tsv"
-    output:
-        filt_tsv = f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.tsv",
-    log: f"cohorts/{cohort}/logs/slivar/tsv/{cohort}.{ref}.pbsv.svpack.log"
-    benchmark: f"cohorts/{cohort}/benchmarks/slivar/tsv/{cohort}.{ref}.pbsv.svpack.tsv"
-    params: info = "".join([f"--info-field {x} " for x in info_fields])
-    conda: "envs/slivar.yaml"
-    message: "Executing {rule}: Converting annotated VCFs to TSVs for easier interpretation."
-    shell:
-        """
-        (slivar tsv \
-            {params.info} \
-            --csq-field BCSQ \
-            --gene-description {input.lof_lookup} \
-            --gene-description {input.clinvar_lookup} \
-            --gene-description {input.phrank_lookup} \
-            --ped {input.ped} \
-            --out {output.filt_tsv} \
-            {input.filt_vcf}) > {log} 2>&1
-        """
+# rule slivar_svpack_tsv:
+#     input:
+#         filt_vcf = f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.vcf.gz",
+#         ped = f"cohorts/{cohort}/{cohort}.ped",
+#         lof_lookup = config['lof_lookup'],
+#         clinvar_lookup = config['clinvar_lookup'],
+#         phrank_lookup = f"cohorts/{cohort}/{cohort}_phrank.tsv"
+#     output:
+#         filt_tsv = f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.tsv",
+#     log: f"cohorts/{cohort}/logs/slivar/tsv/{cohort}.{ref}.pbsv.svpack.log"
+#     benchmark: f"cohorts/{cohort}/benchmarks/slivar/tsv/{cohort}.{ref}.pbsv.svpack.tsv"
+#     params: info = "".join([f"--info-field {x} " for x in info_fields])
+#     conda: "envs/slivar.yaml"
+#     message: "Executing {rule}: Converting annotated VCFs to TSVs for easier interpretation."
+#     shell:
+#         """
+#         (slivar tsv \
+#             {params.info} \
+#             --csq-field BCSQ \
+#             --gene-description {input.lof_lookup} \
+#             --gene-description {input.clinvar_lookup} \
+#             --gene-description {input.phrank_lookup} \
+#             --ped {input.ped} \
+#             --out {output.filt_tsv} \
+#             {input.filt_vcf}) > {log} 2>&1
+#         """

--- a/rules/cohort_svpack.smk
+++ b/rules/cohort_svpack.smk
@@ -20,3 +20,41 @@ rule svpack_filter_annotated:
             python workflow/scripts/svpack/svpack match -v - {input.hprc_pbsv_vcf} | \
             python workflow/scripts/svpack/svpack consequence - {input.gff} > {output}) 2> {log}
         """
+
+
+info_fields = [
+    'SVTYPE',
+    'SVLEN',
+    'SVANN',
+    'CIPOS',
+    'MATEID',
+    'END'
+    ]
+
+
+rule slivar_svpack_tsv:
+    input:
+        filt_vcf = f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.vcf.gz",
+        ped = f"cohorts/{cohort}/{cohort}.ped",
+        lof_lookup = config['lof_lookup'],
+        clinvar_lookup = config['clinvar_lookup'],
+        phrank_lookup = f"cohorts/{cohort}/{cohort}_phrank.tsv"
+    output:
+        filt_tsv = f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.tsv",
+    log: f"cohorts/{cohort}/logs/slivar/tsv/{cohort}.{ref}.pbsv.svpack.log"
+    benchmark: f"cohorts/{cohort}/benchmarks/slivar/tsv/{cohort}.{ref}.pbsv.svpack.tsv"
+    params: info = "".join([f"--info-field {x} " for x in info_fields])
+    conda: "envs/slivar.yaml"
+    message: "Executing {rule}: Converting annotated VCFs to TSVs for easier interpretation."
+    shell:
+        """
+        (slivar tsv \
+            {params.info} \
+            --csq-field BCSQ \
+            --gene-description {input.lof_lookup} \
+            --gene-description {input.clinvar_lookup} \
+            --gene-description {input.phrank_lookup} \
+            --ped {input.ped} \
+            --out {output.filt_tsv} \
+            {input.filt_vcf}) > {log} 2>&1
+        """

--- a/rules/cohort_svpack.smk
+++ b/rules/cohort_svpack.smk
@@ -14,9 +14,9 @@ rule svpack_filter_annotated:
     shell:
         """
         (python workflow/scripts/svpack/svpack filter --pass-only \
-            --min-svlen {params.min_sv_length} {input.pbsv_vcf} |​ \
-            python workflow/scripts/svpack/svpack match -v - {input.eee_vcf} |​ \
-            python workflow/scripts/svpack/svpack match -v - {input.gnomadsv_vcf} |​ \
+            --min-svlen {params.min_sv_length} {input.pbsv_vcf} | \
+            python workflow/scripts/svpack/svpack match -v - {input.eee_vcf} | \
+            python workflow/scripts/svpack/svpack match -v - {input.gnomadsv_vcf} | \
             python workflow/scripts/svpack/svpack match -v - {input.hprc_pbsv_vcf} | \
             python workflow/scripts/svpack/svpack consequence - {input.gff} > {output}) 2> {log}
         """


### PR DESCRIPTION

- Add svpack as a submodule #7 
- Filter common SVs with `svpack filter`
- Annotate consequence of SVs with `svpack consequence`
- rules added for filtering and annotation in `rules/svpack.smk`
- rules used by `process_cohort.smk`
- paths to VCF for annotation added to `reference.yaml`